### PR TITLE
Update to support default meteor roles

### DIFF
--- a/security-rules.js
+++ b/security-rules.js
@@ -39,8 +39,19 @@ Security.defineMethod("ifHasUserId", {
 });
 
 /*
- * Specific Roles
+ * Default Meteor role support
  */
+ Security.defineMethod("ifHasRole", {
+   fetch: [],
+   transform: null,
+   deny: function (type, arg, userId) {
+     if (!arg) {
+       throw new Error('ifHasRole security rule method requires an argument');
+     }
+     return !Roles.userIsInRole(userId, arg);
+   }
+ });
+
 
 /*
  * alanning:roles support


### PR DESCRIPTION
Hey, it looks like the isHasRole() method for Meteor's default role system got dropped.

This PR fixes a run-time error, but I haven't tested it yet.