### PR TITLE
More functional `ownsDocument` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,12 @@ Here's how you might make your own rule that ensures the `ownerId` property on a
 
 ```js
 Security.defineMethod('ownsDocument', {
-  fetch: ['ownerId'],
-  deny: function (type, arg, userId, doc) {
-    return userId !== doc.ownerId;
+  fetch: [],
+  deny: function (type, field, userId, doc) {
+    if(!field){
+      field = 'userId';
+    }
+    return userId !== doc[field];
   }
 });
 ```
@@ -242,7 +245,7 @@ Security.defineMethod('ownsDocument', {
 And then you can use it like this:
 
 ```js
-Posts.permit(['insert', 'update']).ownsDocument().apply();
+Posts.permit(['insert', 'update']).ownsDocument('ownerId').apply();
 ```
 
 Which means:


### PR DESCRIPTION
As this is not obvious for *some* developers how to edit this function to handle such functionality, I'm suggesting this update for docs.
 - Allow in `ownsDocument` security method handle various owner identification fields, default field name is `userId`
 - Security method `ownsDocument` is useless if we can check only by `ownerId`